### PR TITLE
feat: comprehensive SEO improvements

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://komoui.site/sitemap.xml

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,15 +1,253 @@
-export function docsMeta(title: string, description: string, url?: string) {
+export function docsMeta(
+  title: string,
+  description: string,
+  url?: string,
+  section?: string
+) {
+  const canonicalUrl = url ? `https://komoui.site${url}` : "https://komoui.site";
+  const isComponentPage = url?.includes("/docs/components/");
+  const ogType = isComponentPage ? "article" : "website";
+  const pageTitle = isComponentPage
+    ? `KomoUI Component: ${title}`
+    : `${title} - KomoUI`;
+
+  const breadcrumbs = url
+    ? url
+        .split("/")
+        .filter(Boolean)
+        .map((segment, index, arr) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: formatSegment(segment),
+          item: `https://komoui.site/${arr.slice(0, index + 1).join("/")}`,
+        }))
+    : [];
+
+  const techArticleSchema = {
+    "@context": "https://schema.org",
+    "@type": "TechArticle",
+    headline: title,
+    description,
+    url: canonicalUrl,
+    image: "https://komoui.site/og-image.webp",
+    articleSection: section || (isComponentPage ? "Components" : "Documentation"),
+    about: isComponentPage
+      ? {
+          "@type": "SoftwareApplication",
+          name: `KomoUI ${title}`,
+          applicationCategory: "DeveloperApplication",
+          operatingSystem: "Android, iOS, Desktop, Web",
+        }
+      : undefined,
+    publisher: {
+      "@type": "Organization",
+      name: "KomoUI",
+      url: "https://komoui.site",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://komoui.site/android-fav.webp",
+      },
+    },
+  };
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://komoui.site/" },
+      { "@type": "ListItem", position: 2, name: "Documentation", item: "https://komoui.site/docs" },
+      ...breadcrumbs,
+    ],
+  };
+
   return [
     { title: `${title} - KomoUI` },
     { name: "description", content: description },
-    { property: "og:title", content: `KomoUI Component: ${title}` },
+    { property: "og:title", content: pageTitle },
     { property: "og:description", content: description },
     { property: "og:image", content: "https://komoui.site/og-image.webp" },
-    { property: "og:type", content: "website" },
-    ...(url ? [{ property: "og:url", content: `https://komoui.site${url}` }] : []),
+    { property: "og:image:width", content: "1200" },
+    { property: "og:image:height", content: "630" },
+    { property: "og:type", content: ogType },
+    { property: "og:url", content: canonicalUrl },
+    { property: "og:site_name", content: "KomoUI" },
     { name: "twitter:card", content: "summary_large_image" },
-    { name: "twitter:title", content: `KomoUI Component: ${title}` },
+    { name: "twitter:title", content: pageTitle },
     { name: "twitter:description", content: description },
     { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
+    { rel: "canonical", href: canonicalUrl },
+    {
+      script: {
+        type: "application/ld+json",
+        children: JSON.stringify(techArticleSchema),
+      },
+    },
+    {
+      script: {
+        type: "application/ld+json",
+        children: JSON.stringify(breadcrumbSchema),
+      },
+    },
+  ];
+}
+
+function formatSegment(segment: string): string {
+  return segment
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+export function homeMeta() {
+  const webSiteSchema = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "KomoUI",
+    url: "https://komoui.site",
+    description:
+      "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+    publisher: {
+      "@type": "Organization",
+      name: "KomoUI",
+      url: "https://komoui.site",
+    },
+  };
+
+  return [
+    { title: "KomoUI - Kotlin Multiplatform UI Library for Jetpack Compose" },
+    {
+      name: "description",
+      content:
+        "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+    },
+    { property: "og:title", content: "KomoUI" },
+    {
+      property: "og:description",
+      content:
+        "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+    },
+    { property: "og:image", content: "https://komoui.site/og-image.webp" },
+    { property: "og:image:width", content: "1200" },
+    { property: "og:image:height", content: "630" },
+    { property: "og:type", content: "website" },
+    { property: "og:url", content: "https://komoui.site/" },
+    { property: "og:site_name", content: "KomoUI" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: "KomoUI" },
+    {
+      name: "twitter:description",
+      content:
+        "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+    },
+    { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
+    { rel: "canonical", href: "https://komoui.site/" },
+    {
+      script: {
+        type: "application/ld+json",
+        children: JSON.stringify(webSiteSchema),
+      },
+    },
+  ];
+}
+
+export function componentsIndexMeta() {
+  const collectionPageSchema = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: "Components - KomoUI",
+    description:
+      "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+    url: "https://komoui.site/docs/components",
+    hasPart: [
+      { "@type": "WebPage", name: "Button", url: "https://komoui.site/docs/components/button" },
+      { "@type": "WebPage", name: "Input", url: "https://komoui.site/docs/components/input" },
+      { "@type": "WebPage", name: "Select", url: "https://komoui.site/docs/components/select" },
+      { "@type": "WebPage", name: "Dialog", url: "https://komoui.site/docs/components/dialog" },
+      { "@type": "WebPage", name: "Card", url: "https://komoui.site/docs/components/card" },
+      { "@type": "WebPage", name: "Tabs", url: "https://komoui.site/docs/components/tabs" },
+      { "@type": "WebPage", name: "Avatar", url: "https://komoui.site/docs/components/avatar" },
+      { "@type": "WebPage", name: "Badge", url: "https://komoui.site/docs/components/badge" },
+      { "@type": "WebPage", name: "Alert", url: "https://komoui.site/docs/components/alert" },
+      { "@type": "WebPage", name: "Checkbox", url: "https://komoui.site/docs/components/checkbox" },
+      { "@type": "WebPage", name: "Radio Group", url: "https://komoui.site/docs/components/radio-group" },
+      { "@type": "WebPage", name: "Switch", url: "https://komoui.site/docs/components/switch" },
+      { "@type": "WebPage", name: "Slider", url: "https://komoui.site/docs/components/slider" },
+      { "@type": "WebPage", name: "Progress", url: "https://komoui.site/docs/components/progress" },
+      { "@type": "WebPage", name: "Skeleton", url: "https://komoui.site/docs/components/skeleton" },
+      { "@type": "WebPage", name: "Spinner", url: "https://komoui.site/docs/components/spinner" },
+      { "@type": "WebPage", name: "Tooltip", url: "https://komoui.site/docs/components/tooltip" },
+      { "@type": "WebPage", name: "Popover", url: "https://komoui.site/docs/components/popover" },
+      { "@type": "WebPage", name: "Dropdown Menu", url: "https://komoui.site/docs/components/dropdown-menu" },
+      { "@type": "WebPage", name: "Combobox", url: "https://komoui.site/docs/components/combobox" },
+      { "@type": "WebPage", name: "Date Picker", url: "https://komoui.site/docs/components/date-picker" },
+      { "@type": "WebPage", name: "Calendar", url: "https://komoui.site/docs/components/calendar" },
+      { "@type": "WebPage", name: "Input OTP", url: "https://komoui.site/docs/components/input-otp" },
+      { "@type": "WebPage", name: "Drawer", url: "https://komoui.site/docs/components/drawer" },
+      { "@type": "WebPage", name: "Sidebar", url: "https://komoui.site/docs/components/sidebar" },
+      { "@type": "WebPage", name: "Accordion", url: "https://komoui.site/docs/components/accordion" },
+      { "@type": "WebPage", name: "Collapsible", url: "https://komoui.site/docs/components/collapsible" },
+      { "@type": "WebPage", name: "Carousel", url: "https://komoui.site/docs/components/carousel" },
+      { "@type": "WebPage", name: "Chart", url: "https://komoui.site/docs/components/chart" },
+      { "@type": "WebPage", name: "Data Table", url: "https://komoui.site/docs/components/data-table" },
+      { "@type": "WebPage", name: "Sonner", url: "https://komoui.site/docs/components/sonner" },
+      { "@type": "WebPage", name: "Alert Dialog", url: "https://komoui.site/docs/components/alert-dialog" },
+    ],
+    publisher: {
+      "@type": "Organization",
+      name: "KomoUI",
+      url: "https://komoui.site",
+    },
+  };
+
+  const breadcrumbSchema = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: "https://komoui.site/" },
+      { "@type": "ListItem", position: 2, name: "Documentation", item: "https://komoui.site/docs" },
+      { "@type": "ListItem", position: 3, name: "Components", item: "https://komoui.site/docs/components" },
+    ],
+  };
+
+  return [
+    { title: "Components - KomoUI" },
+    {
+      name: "description",
+      content:
+        "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+    },
+    { property: "og:title", content: "Components - KomoUI" },
+    {
+      property: "og:description",
+      content:
+        "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+    },
+    { property: "og:image", content: "https://komoui.site/og-image.webp" },
+    { property: "og:image:width", content: "1200" },
+    { property: "og:image:height", content: "630" },
+    { property: "og:type", content: "website" },
+    { property: "og:url", content: "https://komoui.site/docs/components" },
+    { property: "og:site_name", content: "KomoUI" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: "Components - KomoUI" },
+    {
+      name: "twitter:description",
+      content:
+        "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+    },
+    { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
+    { rel: "canonical", href: "https://komoui.site/docs/components" },
+    {
+      script: {
+        type: "application/ld+json",
+        children: JSON.stringify(collectionPageSchema),
+      },
+    },
+    {
+      script: {
+        type: "application/ld+json",
+        children: JSON.stringify(breadcrumbSchema),
+      },
+    },
   ];
 }

--- a/src/routes/docs/components/accordion.tsx
+++ b/src/routes/docs/components/accordion.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/accordion")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/accordion", "Components") }),
 });

--- a/src/routes/docs/components/alert-dialog.tsx
+++ b/src/routes/docs/components/alert-dialog.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/alert-dialog")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/alert-dialog", "Components") }),
 });

--- a/src/routes/docs/components/alert.tsx
+++ b/src/routes/docs/components/alert.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/alert")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/alert", "Components") }),
 });

--- a/src/routes/docs/components/avatar.tsx
+++ b/src/routes/docs/components/avatar.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/avatar")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/avatar", "Components") }),
 });

--- a/src/routes/docs/components/badge.tsx
+++ b/src/routes/docs/components/badge.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/badge")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/badge", "Components") }),
 });

--- a/src/routes/docs/components/button.tsx
+++ b/src/routes/docs/components/button.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/button")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/button", "Components") }),
 });

--- a/src/routes/docs/components/calendar.tsx
+++ b/src/routes/docs/components/calendar.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/calendar")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/calendar", "Components") }),
 });

--- a/src/routes/docs/components/card.tsx
+++ b/src/routes/docs/components/card.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/card")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/card", "Components") }),
 });

--- a/src/routes/docs/components/carousel.tsx
+++ b/src/routes/docs/components/carousel.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/carousel")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/carousel", "Components") }),
 });

--- a/src/routes/docs/components/chart.tsx
+++ b/src/routes/docs/components/chart.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/chart")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/chart", "Components") }),
 });

--- a/src/routes/docs/components/checkbox.tsx
+++ b/src/routes/docs/components/checkbox.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/checkbox")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/checkbox", "Components") }),
 });

--- a/src/routes/docs/components/collapsible.tsx
+++ b/src/routes/docs/components/collapsible.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/collapsible")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/collapsible", "Components") }),
 });

--- a/src/routes/docs/components/combobox.tsx
+++ b/src/routes/docs/components/combobox.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/combobox")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/combobox", "Components") }),
 });

--- a/src/routes/docs/components/data-table.tsx
+++ b/src/routes/docs/components/data-table.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/data-table")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/data-table", "Components") }),
 });

--- a/src/routes/docs/components/date-picker.tsx
+++ b/src/routes/docs/components/date-picker.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/date-picker")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/date-picker", "Components") }),
 });

--- a/src/routes/docs/components/dialog.tsx
+++ b/src/routes/docs/components/dialog.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/dialog")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/dialog", "Components") }),
 });

--- a/src/routes/docs/components/drawer.tsx
+++ b/src/routes/docs/components/drawer.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/drawer")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/drawer", "Components") }),
 });

--- a/src/routes/docs/components/dropdown-menu.tsx
+++ b/src/routes/docs/components/dropdown-menu.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/dropdown-menu")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/dropdown-menu", "Components") }),
 });

--- a/src/routes/docs/components/index.tsx
+++ b/src/routes/docs/components/index.tsx
@@ -1,16 +1,11 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Separator } from "@/components/ui/separator";
 import componentMenus from "@/lib/component-menu";
-import { docsMeta } from "@/lib/seo";
+import { componentsIndexMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/")({
   component: ComponentsView,
-  head: () => ({
-    meta: docsMeta(
-      "Components",
-      "Here you can find all the components available in the library."
-    ),
-  }),
+  head: () => ({ meta: componentsIndexMeta() }),
 });
 
 function ComponentsView() {

--- a/src/routes/docs/components/input-otp.tsx
+++ b/src/routes/docs/components/input-otp.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/input-otp")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/input-otp", "Components") }),
 });

--- a/src/routes/docs/components/input.tsx
+++ b/src/routes/docs/components/input.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/input")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/input", "Components") }),
 });

--- a/src/routes/docs/components/popover.tsx
+++ b/src/routes/docs/components/popover.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/popover")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/popover", "Components") }),
 });

--- a/src/routes/docs/components/progress.tsx
+++ b/src/routes/docs/components/progress.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/progress")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/progress", "Components") }),
 });

--- a/src/routes/docs/components/radio-group.tsx
+++ b/src/routes/docs/components/radio-group.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/radio-group")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/radio-group", "Components") }),
 });

--- a/src/routes/docs/components/select.tsx
+++ b/src/routes/docs/components/select.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/select")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/select", "Components") }),
 });

--- a/src/routes/docs/components/sidebar.tsx
+++ b/src/routes/docs/components/sidebar.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/sidebar")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/sidebar", "Components") }),
 });

--- a/src/routes/docs/components/skeleton.tsx
+++ b/src/routes/docs/components/skeleton.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/skeleton")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/skeleton", "Components") }),
 });

--- a/src/routes/docs/components/slider.tsx
+++ b/src/routes/docs/components/slider.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/slider")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/slider", "Components") }),
 });

--- a/src/routes/docs/components/sonner.tsx
+++ b/src/routes/docs/components/sonner.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/sonner")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/sonner", "Components") }),
 });

--- a/src/routes/docs/components/spinner.tsx
+++ b/src/routes/docs/components/spinner.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/spinner")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/spinner", "Components") }),
 });

--- a/src/routes/docs/components/switch.tsx
+++ b/src/routes/docs/components/switch.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/switch")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/switch", "Components") }),
 });

--- a/src/routes/docs/components/tabs.tsx
+++ b/src/routes/docs/components/tabs.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/tabs")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/tabs", "Components") }),
 });

--- a/src/routes/docs/installation.tsx
+++ b/src/routes/docs/installation.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/installation")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/installation", "Getting Started") }),
 });

--- a/src/routes/docs/introduction.tsx
+++ b/src/routes/docs/introduction.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/introduction")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/introduction", "Getting Started") }),
 });

--- a/src/routes/docs/tailwind-to-kotlin.tsx
+++ b/src/routes/docs/tailwind-to-kotlin.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/tailwind-to-kotlin")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/tailwind-to-kotlin", "Getting Started") }),
 });

--- a/src/routes/docs/theming.tsx
+++ b/src/routes/docs/theming.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/theming")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description) }),
+  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/theming", "Getting Started") }),
 });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,8 +3,10 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Header } from "@/components/home/header";
 import { Hero } from "@/components/home/hero";
 import { Examples } from "@/components/home/examples";
+import { homeMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/")({
+  head: () => ({ meta: homeMeta() }),
   component: HomePage,
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,16 @@ export default defineConfig({
   plugins: [
     cloudflare({ viteEnvironment: { name: "ssr" } }),
     tailwindcss(),
-    tanstackStart(),
+    tanstackStart({
+      prerender: {
+        enabled: true,
+        crawlLinks: true,
+      },
+      sitemap: {
+        enabled: true,
+        host: "https://komoui.site",
+      },
+    }),
     {
       enforce: "pre",
       ...mdx({


### PR DESCRIPTION
- Enable static prerendering + sitemap generation (vite.config.ts)
- Add robots.txt with sitemap reference
- Enhance docsMeta() with canonical URLs, JSON-LD (TechArticle + BreadcrumbList), enhanced OG/Twitter meta
- Add homeMeta() with WebSite schema
- Add componentsIndexMeta() with CollectionPage schema
- Update all 35 doc/component routes to pass URL + section to docsMeta()
- Add SEO head exports to home page and components index