### PR TITLE
fix: remove trailing slash duplicate in sitemap

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,21 +3,27 @@ project_name: "shadcn-compose-docs"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   java                julia               kotlin              lua                 markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   svelte              swift               systemverilog       terraform           toml
+#   typescript          typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -59,53 +65,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project by name.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_lines`: Deletes a range of lines within a file.
-#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
-#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
-#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Gets the initial instructions for the current project.
-#     Should only be used in settings where the system prompt cannot be set,
-#     e.g. in clients you have no control over, like Claude Desktop.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_at_line`: Inserts content at a given line in a file.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: Lists memories in Serena's project-specific memory store.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
-#  * `remove_project`: Removes a project from the Serena configuration.
-#  * `replace_lines`: Replaces a range of lines within a file with new content.
-#  * `replace_symbol_body`: Replaces the full definition of a symbol.
-#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
-#  * `switch_modes`: Activates modes by providing a list of their names
-#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
-#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
-#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
-#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -116,11 +86,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -136,3 +109,33 @@ symbol_info_budget:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,7 +15,7 @@ import { Route as DocsThemingRouteImport } from './routes/docs/theming'
 import { Route as DocsTailwindToKotlinRouteImport } from './routes/docs/tailwind-to-kotlin'
 import { Route as DocsIntroductionRouteImport } from './routes/docs/introduction'
 import { Route as DocsInstallationRouteImport } from './routes/docs/installation'
-import { Route as DocsComponentsIndexRouteImport } from './routes/docs/components/index'
+import { Route as DocsComponentsRouteImport } from './routes/docs/components'
 import { Route as DocsComponentsTabsRouteImport } from './routes/docs/components/tabs'
 import { Route as DocsComponentsSwitchRouteImport } from './routes/docs/components/switch'
 import { Route as DocsComponentsSpinnerRouteImport } from './routes/docs/components/spinner'
@@ -78,175 +78,176 @@ const DocsInstallationRoute = DocsInstallationRouteImport.update({
   path: '/installation',
   getParentRoute: () => DocsRouteRoute,
 } as any)
-const DocsComponentsIndexRoute = DocsComponentsIndexRouteImport.update({
-  id: '/components/',
-  path: '/components/',
+const DocsComponentsRoute = DocsComponentsRouteImport.update({
+  id: '/components',
+  path: '/components',
   getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsTabsRoute = DocsComponentsTabsRouteImport.update({
-  id: '/components/tabs',
-  path: '/components/tabs',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/tabs',
+  path: '/tabs',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSwitchRoute = DocsComponentsSwitchRouteImport.update({
-  id: '/components/switch',
-  path: '/components/switch',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/switch',
+  path: '/switch',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSpinnerRoute = DocsComponentsSpinnerRouteImport.update({
-  id: '/components/spinner',
-  path: '/components/spinner',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/spinner',
+  path: '/spinner',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSonnerRoute = DocsComponentsSonnerRouteImport.update({
-  id: '/components/sonner',
-  path: '/components/sonner',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/sonner',
+  path: '/sonner',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSliderRoute = DocsComponentsSliderRouteImport.update({
-  id: '/components/slider',
-  path: '/components/slider',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/slider',
+  path: '/slider',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSkeletonRoute = DocsComponentsSkeletonRouteImport.update({
-  id: '/components/skeleton',
-  path: '/components/skeleton',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/skeleton',
+  path: '/skeleton',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSidebarRoute = DocsComponentsSidebarRouteImport.update({
-  id: '/components/sidebar',
-  path: '/components/sidebar',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/sidebar',
+  path: '/sidebar',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsSelectRoute = DocsComponentsSelectRouteImport.update({
-  id: '/components/select',
-  path: '/components/select',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/select',
+  path: '/select',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsRadioGroupRoute =
   DocsComponentsRadioGroupRouteImport.update({
-    id: '/components/radio-group',
-    path: '/components/radio-group',
-    getParentRoute: () => DocsRouteRoute,
+    id: '/radio-group',
+    path: '/radio-group',
+    getParentRoute: () => DocsComponentsRoute,
   } as any)
 const DocsComponentsProgressRoute = DocsComponentsProgressRouteImport.update({
-  id: '/components/progress',
-  path: '/components/progress',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/progress',
+  path: '/progress',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsPopoverRoute = DocsComponentsPopoverRouteImport.update({
-  id: '/components/popover',
-  path: '/components/popover',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/popover',
+  path: '/popover',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsInputOtpRoute = DocsComponentsInputOtpRouteImport.update({
-  id: '/components/input-otp',
-  path: '/components/input-otp',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/input-otp',
+  path: '/input-otp',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsInputRoute = DocsComponentsInputRouteImport.update({
-  id: '/components/input',
-  path: '/components/input',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/input',
+  path: '/input',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsDropdownMenuRoute =
   DocsComponentsDropdownMenuRouteImport.update({
-    id: '/components/dropdown-menu',
-    path: '/components/dropdown-menu',
-    getParentRoute: () => DocsRouteRoute,
+    id: '/dropdown-menu',
+    path: '/dropdown-menu',
+    getParentRoute: () => DocsComponentsRoute,
   } as any)
 const DocsComponentsDrawerRoute = DocsComponentsDrawerRouteImport.update({
-  id: '/components/drawer',
-  path: '/components/drawer',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/drawer',
+  path: '/drawer',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsDialogRoute = DocsComponentsDialogRouteImport.update({
-  id: '/components/dialog',
-  path: '/components/dialog',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/dialog',
+  path: '/dialog',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsDatePickerRoute =
   DocsComponentsDatePickerRouteImport.update({
-    id: '/components/date-picker',
-    path: '/components/date-picker',
-    getParentRoute: () => DocsRouteRoute,
+    id: '/date-picker',
+    path: '/date-picker',
+    getParentRoute: () => DocsComponentsRoute,
   } as any)
 const DocsComponentsDataTableRoute = DocsComponentsDataTableRouteImport.update({
-  id: '/components/data-table',
-  path: '/components/data-table',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/data-table',
+  path: '/data-table',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsComboboxRoute = DocsComponentsComboboxRouteImport.update({
-  id: '/components/combobox',
-  path: '/components/combobox',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/combobox',
+  path: '/combobox',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsCollapsibleRoute =
   DocsComponentsCollapsibleRouteImport.update({
-    id: '/components/collapsible',
-    path: '/components/collapsible',
-    getParentRoute: () => DocsRouteRoute,
+    id: '/collapsible',
+    path: '/collapsible',
+    getParentRoute: () => DocsComponentsRoute,
   } as any)
 const DocsComponentsCheckboxRoute = DocsComponentsCheckboxRouteImport.update({
-  id: '/components/checkbox',
-  path: '/components/checkbox',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/checkbox',
+  path: '/checkbox',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsChartRoute = DocsComponentsChartRouteImport.update({
-  id: '/components/chart',
-  path: '/components/chart',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/chart',
+  path: '/chart',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsCarouselRoute = DocsComponentsCarouselRouteImport.update({
-  id: '/components/carousel',
-  path: '/components/carousel',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/carousel',
+  path: '/carousel',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsCardRoute = DocsComponentsCardRouteImport.update({
-  id: '/components/card',
-  path: '/components/card',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/card',
+  path: '/card',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsCalendarRoute = DocsComponentsCalendarRouteImport.update({
-  id: '/components/calendar',
-  path: '/components/calendar',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/calendar',
+  path: '/calendar',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsButtonRoute = DocsComponentsButtonRouteImport.update({
-  id: '/components/button',
-  path: '/components/button',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/button',
+  path: '/button',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsBadgeRoute = DocsComponentsBadgeRouteImport.update({
-  id: '/components/badge',
-  path: '/components/badge',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/badge',
+  path: '/badge',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsAvatarRoute = DocsComponentsAvatarRouteImport.update({
-  id: '/components/avatar',
-  path: '/components/avatar',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/avatar',
+  path: '/avatar',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsAlertDialogRoute =
   DocsComponentsAlertDialogRouteImport.update({
-    id: '/components/alert-dialog',
-    path: '/components/alert-dialog',
-    getParentRoute: () => DocsRouteRoute,
+    id: '/alert-dialog',
+    path: '/alert-dialog',
+    getParentRoute: () => DocsComponentsRoute,
   } as any)
 const DocsComponentsAlertRoute = DocsComponentsAlertRouteImport.update({
-  id: '/components/alert',
-  path: '/components/alert',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/alert',
+  path: '/alert',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 const DocsComponentsAccordionRoute = DocsComponentsAccordionRouteImport.update({
-  id: '/components/accordion',
-  path: '/components/accordion',
-  getParentRoute: () => DocsRouteRoute,
+  id: '/accordion',
+  path: '/accordion',
+  getParentRoute: () => DocsComponentsRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
+  '/docs/components': typeof DocsComponentsRouteWithChildren
   '/docs/installation': typeof DocsInstallationRoute
   '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/tailwind-to-kotlin': typeof DocsTailwindToKotlinRoute
@@ -282,11 +283,11 @@ export interface FileRoutesByFullPath {
   '/docs/components/spinner': typeof DocsComponentsSpinnerRoute
   '/docs/components/switch': typeof DocsComponentsSwitchRoute
   '/docs/components/tabs': typeof DocsComponentsTabsRoute
-  '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
+  '/docs/components': typeof DocsComponentsRouteWithChildren
   '/docs/installation': typeof DocsInstallationRoute
   '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/tailwind-to-kotlin': typeof DocsTailwindToKotlinRoute
@@ -322,12 +323,12 @@ export interface FileRoutesByTo {
   '/docs/components/spinner': typeof DocsComponentsSpinnerRoute
   '/docs/components/switch': typeof DocsComponentsSwitchRoute
   '/docs/components/tabs': typeof DocsComponentsTabsRoute
-  '/docs/components': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
+  '/docs/components': typeof DocsComponentsRouteWithChildren
   '/docs/installation': typeof DocsInstallationRoute
   '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/tailwind-to-kotlin': typeof DocsTailwindToKotlinRoute
@@ -363,13 +364,13 @@ export interface FileRoutesById {
   '/docs/components/spinner': typeof DocsComponentsSpinnerRoute
   '/docs/components/switch': typeof DocsComponentsSwitchRoute
   '/docs/components/tabs': typeof DocsComponentsTabsRoute
-  '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/docs'
+    | '/docs/components'
     | '/docs/installation'
     | '/docs/introduction'
     | '/docs/tailwind-to-kotlin'
@@ -405,11 +406,11 @@ export interface FileRouteTypes {
     | '/docs/components/spinner'
     | '/docs/components/switch'
     | '/docs/components/tabs'
-    | '/docs/components/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/docs'
+    | '/docs/components'
     | '/docs/installation'
     | '/docs/introduction'
     | '/docs/tailwind-to-kotlin'
@@ -445,11 +446,11 @@ export interface FileRouteTypes {
     | '/docs/components/spinner'
     | '/docs/components/switch'
     | '/docs/components/tabs'
-    | '/docs/components'
   id:
     | '__root__'
     | '/'
     | '/docs'
+    | '/docs/components'
     | '/docs/installation'
     | '/docs/introduction'
     | '/docs/tailwind-to-kotlin'
@@ -485,7 +486,6 @@ export interface FileRouteTypes {
     | '/docs/components/spinner'
     | '/docs/components/switch'
     | '/docs/components/tabs'
-    | '/docs/components/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -537,238 +537,234 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsInstallationRouteImport
       parentRoute: typeof DocsRouteRoute
     }
-    '/docs/components/': {
-      id: '/docs/components/'
+    '/docs/components': {
+      id: '/docs/components'
       path: '/components'
-      fullPath: '/docs/components/'
-      preLoaderRoute: typeof DocsComponentsIndexRouteImport
+      fullPath: '/docs/components'
+      preLoaderRoute: typeof DocsComponentsRouteImport
       parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/tabs': {
       id: '/docs/components/tabs'
-      path: '/components/tabs'
+      path: '/tabs'
       fullPath: '/docs/components/tabs'
       preLoaderRoute: typeof DocsComponentsTabsRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/switch': {
       id: '/docs/components/switch'
-      path: '/components/switch'
+      path: '/switch'
       fullPath: '/docs/components/switch'
       preLoaderRoute: typeof DocsComponentsSwitchRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/spinner': {
       id: '/docs/components/spinner'
-      path: '/components/spinner'
+      path: '/spinner'
       fullPath: '/docs/components/spinner'
       preLoaderRoute: typeof DocsComponentsSpinnerRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/sonner': {
       id: '/docs/components/sonner'
-      path: '/components/sonner'
+      path: '/sonner'
       fullPath: '/docs/components/sonner'
       preLoaderRoute: typeof DocsComponentsSonnerRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/slider': {
       id: '/docs/components/slider'
-      path: '/components/slider'
+      path: '/slider'
       fullPath: '/docs/components/slider'
       preLoaderRoute: typeof DocsComponentsSliderRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/skeleton': {
       id: '/docs/components/skeleton'
-      path: '/components/skeleton'
+      path: '/skeleton'
       fullPath: '/docs/components/skeleton'
       preLoaderRoute: typeof DocsComponentsSkeletonRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/sidebar': {
       id: '/docs/components/sidebar'
-      path: '/components/sidebar'
+      path: '/sidebar'
       fullPath: '/docs/components/sidebar'
       preLoaderRoute: typeof DocsComponentsSidebarRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/select': {
       id: '/docs/components/select'
-      path: '/components/select'
+      path: '/select'
       fullPath: '/docs/components/select'
       preLoaderRoute: typeof DocsComponentsSelectRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/radio-group': {
       id: '/docs/components/radio-group'
-      path: '/components/radio-group'
+      path: '/radio-group'
       fullPath: '/docs/components/radio-group'
       preLoaderRoute: typeof DocsComponentsRadioGroupRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/progress': {
       id: '/docs/components/progress'
-      path: '/components/progress'
+      path: '/progress'
       fullPath: '/docs/components/progress'
       preLoaderRoute: typeof DocsComponentsProgressRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/popover': {
       id: '/docs/components/popover'
-      path: '/components/popover'
+      path: '/popover'
       fullPath: '/docs/components/popover'
       preLoaderRoute: typeof DocsComponentsPopoverRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/input-otp': {
       id: '/docs/components/input-otp'
-      path: '/components/input-otp'
+      path: '/input-otp'
       fullPath: '/docs/components/input-otp'
       preLoaderRoute: typeof DocsComponentsInputOtpRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/input': {
       id: '/docs/components/input'
-      path: '/components/input'
+      path: '/input'
       fullPath: '/docs/components/input'
       preLoaderRoute: typeof DocsComponentsInputRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/dropdown-menu': {
       id: '/docs/components/dropdown-menu'
-      path: '/components/dropdown-menu'
+      path: '/dropdown-menu'
       fullPath: '/docs/components/dropdown-menu'
       preLoaderRoute: typeof DocsComponentsDropdownMenuRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/drawer': {
       id: '/docs/components/drawer'
-      path: '/components/drawer'
+      path: '/drawer'
       fullPath: '/docs/components/drawer'
       preLoaderRoute: typeof DocsComponentsDrawerRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/dialog': {
       id: '/docs/components/dialog'
-      path: '/components/dialog'
+      path: '/dialog'
       fullPath: '/docs/components/dialog'
       preLoaderRoute: typeof DocsComponentsDialogRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/date-picker': {
       id: '/docs/components/date-picker'
-      path: '/components/date-picker'
+      path: '/date-picker'
       fullPath: '/docs/components/date-picker'
       preLoaderRoute: typeof DocsComponentsDatePickerRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/data-table': {
       id: '/docs/components/data-table'
-      path: '/components/data-table'
+      path: '/data-table'
       fullPath: '/docs/components/data-table'
       preLoaderRoute: typeof DocsComponentsDataTableRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/combobox': {
       id: '/docs/components/combobox'
-      path: '/components/combobox'
+      path: '/combobox'
       fullPath: '/docs/components/combobox'
       preLoaderRoute: typeof DocsComponentsComboboxRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/collapsible': {
       id: '/docs/components/collapsible'
-      path: '/components/collapsible'
+      path: '/collapsible'
       fullPath: '/docs/components/collapsible'
       preLoaderRoute: typeof DocsComponentsCollapsibleRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/checkbox': {
       id: '/docs/components/checkbox'
-      path: '/components/checkbox'
+      path: '/checkbox'
       fullPath: '/docs/components/checkbox'
       preLoaderRoute: typeof DocsComponentsCheckboxRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/chart': {
       id: '/docs/components/chart'
-      path: '/components/chart'
+      path: '/chart'
       fullPath: '/docs/components/chart'
       preLoaderRoute: typeof DocsComponentsChartRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/carousel': {
       id: '/docs/components/carousel'
-      path: '/components/carousel'
+      path: '/carousel'
       fullPath: '/docs/components/carousel'
       preLoaderRoute: typeof DocsComponentsCarouselRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/card': {
       id: '/docs/components/card'
-      path: '/components/card'
+      path: '/card'
       fullPath: '/docs/components/card'
       preLoaderRoute: typeof DocsComponentsCardRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/calendar': {
       id: '/docs/components/calendar'
-      path: '/components/calendar'
+      path: '/calendar'
       fullPath: '/docs/components/calendar'
       preLoaderRoute: typeof DocsComponentsCalendarRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/button': {
       id: '/docs/components/button'
-      path: '/components/button'
+      path: '/button'
       fullPath: '/docs/components/button'
       preLoaderRoute: typeof DocsComponentsButtonRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/badge': {
       id: '/docs/components/badge'
-      path: '/components/badge'
+      path: '/badge'
       fullPath: '/docs/components/badge'
       preLoaderRoute: typeof DocsComponentsBadgeRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/avatar': {
       id: '/docs/components/avatar'
-      path: '/components/avatar'
+      path: '/avatar'
       fullPath: '/docs/components/avatar'
       preLoaderRoute: typeof DocsComponentsAvatarRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/alert-dialog': {
       id: '/docs/components/alert-dialog'
-      path: '/components/alert-dialog'
+      path: '/alert-dialog'
       fullPath: '/docs/components/alert-dialog'
       preLoaderRoute: typeof DocsComponentsAlertDialogRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/alert': {
       id: '/docs/components/alert'
-      path: '/components/alert'
+      path: '/alert'
       fullPath: '/docs/components/alert'
       preLoaderRoute: typeof DocsComponentsAlertRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
     '/docs/components/accordion': {
       id: '/docs/components/accordion'
-      path: '/components/accordion'
+      path: '/accordion'
       fullPath: '/docs/components/accordion'
       preLoaderRoute: typeof DocsComponentsAccordionRouteImport
-      parentRoute: typeof DocsRouteRoute
+      parentRoute: typeof DocsComponentsRoute
     }
   }
 }
 
-interface DocsRouteRouteChildren {
-  DocsInstallationRoute: typeof DocsInstallationRoute
-  DocsIntroductionRoute: typeof DocsIntroductionRoute
-  DocsTailwindToKotlinRoute: typeof DocsTailwindToKotlinRoute
-  DocsThemingRoute: typeof DocsThemingRoute
+interface DocsComponentsRouteChildren {
   DocsComponentsAccordionRoute: typeof DocsComponentsAccordionRoute
   DocsComponentsAlertRoute: typeof DocsComponentsAlertRoute
   DocsComponentsAlertDialogRoute: typeof DocsComponentsAlertDialogRoute
@@ -800,14 +796,9 @@ interface DocsRouteRouteChildren {
   DocsComponentsSpinnerRoute: typeof DocsComponentsSpinnerRoute
   DocsComponentsSwitchRoute: typeof DocsComponentsSwitchRoute
   DocsComponentsTabsRoute: typeof DocsComponentsTabsRoute
-  DocsComponentsIndexRoute: typeof DocsComponentsIndexRoute
 }
 
-const DocsRouteRouteChildren: DocsRouteRouteChildren = {
-  DocsInstallationRoute: DocsInstallationRoute,
-  DocsIntroductionRoute: DocsIntroductionRoute,
-  DocsTailwindToKotlinRoute: DocsTailwindToKotlinRoute,
-  DocsThemingRoute: DocsThemingRoute,
+const DocsComponentsRouteChildren: DocsComponentsRouteChildren = {
   DocsComponentsAccordionRoute: DocsComponentsAccordionRoute,
   DocsComponentsAlertRoute: DocsComponentsAlertRoute,
   DocsComponentsAlertDialogRoute: DocsComponentsAlertDialogRoute,
@@ -839,7 +830,26 @@ const DocsRouteRouteChildren: DocsRouteRouteChildren = {
   DocsComponentsSpinnerRoute: DocsComponentsSpinnerRoute,
   DocsComponentsSwitchRoute: DocsComponentsSwitchRoute,
   DocsComponentsTabsRoute: DocsComponentsTabsRoute,
-  DocsComponentsIndexRoute: DocsComponentsIndexRoute,
+}
+
+const DocsComponentsRouteWithChildren = DocsComponentsRoute._addFileChildren(
+  DocsComponentsRouteChildren,
+)
+
+interface DocsRouteRouteChildren {
+  DocsComponentsRoute: typeof DocsComponentsRouteWithChildren
+  DocsInstallationRoute: typeof DocsInstallationRoute
+  DocsIntroductionRoute: typeof DocsIntroductionRoute
+  DocsTailwindToKotlinRoute: typeof DocsTailwindToKotlinRoute
+  DocsThemingRoute: typeof DocsThemingRoute
+}
+
+const DocsRouteRouteChildren: DocsRouteRouteChildren = {
+  DocsComponentsRoute: DocsComponentsRouteWithChildren,
+  DocsInstallationRoute: DocsInstallationRoute,
+  DocsIntroductionRoute: DocsIntroductionRoute,
+  DocsTailwindToKotlinRoute: DocsTailwindToKotlinRoute,
+  DocsThemingRoute: DocsThemingRoute,
 }
 
 const DocsRouteRouteWithChildren = DocsRouteRoute._addFileChildren(

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,7 +15,7 @@ import { Route as DocsThemingRouteImport } from './routes/docs/theming'
 import { Route as DocsTailwindToKotlinRouteImport } from './routes/docs/tailwind-to-kotlin'
 import { Route as DocsIntroductionRouteImport } from './routes/docs/introduction'
 import { Route as DocsInstallationRouteImport } from './routes/docs/installation'
-import { Route as DocsComponentsRouteImport } from './routes/docs/components'
+import { Route as DocsComponentsIndexRouteImport } from './routes/docs/components.index'
 import { Route as DocsComponentsTabsRouteImport } from './routes/docs/components/tabs'
 import { Route as DocsComponentsSwitchRouteImport } from './routes/docs/components/switch'
 import { Route as DocsComponentsSpinnerRouteImport } from './routes/docs/components/spinner'
@@ -78,176 +78,175 @@ const DocsInstallationRoute = DocsInstallationRouteImport.update({
   path: '/installation',
   getParentRoute: () => DocsRouteRoute,
 } as any)
-const DocsComponentsRoute = DocsComponentsRouteImport.update({
-  id: '/components',
-  path: '/components',
+const DocsComponentsIndexRoute = DocsComponentsIndexRouteImport.update({
+  id: '/components/',
+  path: '/components/',
   getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsTabsRoute = DocsComponentsTabsRouteImport.update({
-  id: '/tabs',
-  path: '/tabs',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/tabs',
+  path: '/components/tabs',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSwitchRoute = DocsComponentsSwitchRouteImport.update({
-  id: '/switch',
-  path: '/switch',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/switch',
+  path: '/components/switch',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSpinnerRoute = DocsComponentsSpinnerRouteImport.update({
-  id: '/spinner',
-  path: '/spinner',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/spinner',
+  path: '/components/spinner',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSonnerRoute = DocsComponentsSonnerRouteImport.update({
-  id: '/sonner',
-  path: '/sonner',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/sonner',
+  path: '/components/sonner',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSliderRoute = DocsComponentsSliderRouteImport.update({
-  id: '/slider',
-  path: '/slider',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/slider',
+  path: '/components/slider',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSkeletonRoute = DocsComponentsSkeletonRouteImport.update({
-  id: '/skeleton',
-  path: '/skeleton',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/skeleton',
+  path: '/components/skeleton',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSidebarRoute = DocsComponentsSidebarRouteImport.update({
-  id: '/sidebar',
-  path: '/sidebar',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/sidebar',
+  path: '/components/sidebar',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsSelectRoute = DocsComponentsSelectRouteImport.update({
-  id: '/select',
-  path: '/select',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/select',
+  path: '/components/select',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsRadioGroupRoute =
   DocsComponentsRadioGroupRouteImport.update({
-    id: '/radio-group',
-    path: '/radio-group',
-    getParentRoute: () => DocsComponentsRoute,
+    id: '/components/radio-group',
+    path: '/components/radio-group',
+    getParentRoute: () => DocsRouteRoute,
   } as any)
 const DocsComponentsProgressRoute = DocsComponentsProgressRouteImport.update({
-  id: '/progress',
-  path: '/progress',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/progress',
+  path: '/components/progress',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsPopoverRoute = DocsComponentsPopoverRouteImport.update({
-  id: '/popover',
-  path: '/popover',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/popover',
+  path: '/components/popover',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsInputOtpRoute = DocsComponentsInputOtpRouteImport.update({
-  id: '/input-otp',
-  path: '/input-otp',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/input-otp',
+  path: '/components/input-otp',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsInputRoute = DocsComponentsInputRouteImport.update({
-  id: '/input',
-  path: '/input',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/input',
+  path: '/components/input',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsDropdownMenuRoute =
   DocsComponentsDropdownMenuRouteImport.update({
-    id: '/dropdown-menu',
-    path: '/dropdown-menu',
-    getParentRoute: () => DocsComponentsRoute,
+    id: '/components/dropdown-menu',
+    path: '/components/dropdown-menu',
+    getParentRoute: () => DocsRouteRoute,
   } as any)
 const DocsComponentsDrawerRoute = DocsComponentsDrawerRouteImport.update({
-  id: '/drawer',
-  path: '/drawer',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/drawer',
+  path: '/components/drawer',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsDialogRoute = DocsComponentsDialogRouteImport.update({
-  id: '/dialog',
-  path: '/dialog',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/dialog',
+  path: '/components/dialog',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsDatePickerRoute =
   DocsComponentsDatePickerRouteImport.update({
-    id: '/date-picker',
-    path: '/date-picker',
-    getParentRoute: () => DocsComponentsRoute,
+    id: '/components/date-picker',
+    path: '/components/date-picker',
+    getParentRoute: () => DocsRouteRoute,
   } as any)
 const DocsComponentsDataTableRoute = DocsComponentsDataTableRouteImport.update({
-  id: '/data-table',
-  path: '/data-table',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/data-table',
+  path: '/components/data-table',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsComboboxRoute = DocsComponentsComboboxRouteImport.update({
-  id: '/combobox',
-  path: '/combobox',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/combobox',
+  path: '/components/combobox',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsCollapsibleRoute =
   DocsComponentsCollapsibleRouteImport.update({
-    id: '/collapsible',
-    path: '/collapsible',
-    getParentRoute: () => DocsComponentsRoute,
+    id: '/components/collapsible',
+    path: '/components/collapsible',
+    getParentRoute: () => DocsRouteRoute,
   } as any)
 const DocsComponentsCheckboxRoute = DocsComponentsCheckboxRouteImport.update({
-  id: '/checkbox',
-  path: '/checkbox',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/checkbox',
+  path: '/components/checkbox',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsChartRoute = DocsComponentsChartRouteImport.update({
-  id: '/chart',
-  path: '/chart',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/chart',
+  path: '/components/chart',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsCarouselRoute = DocsComponentsCarouselRouteImport.update({
-  id: '/carousel',
-  path: '/carousel',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/carousel',
+  path: '/components/carousel',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsCardRoute = DocsComponentsCardRouteImport.update({
-  id: '/card',
-  path: '/card',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/card',
+  path: '/components/card',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsCalendarRoute = DocsComponentsCalendarRouteImport.update({
-  id: '/calendar',
-  path: '/calendar',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/calendar',
+  path: '/components/calendar',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsButtonRoute = DocsComponentsButtonRouteImport.update({
-  id: '/button',
-  path: '/button',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/button',
+  path: '/components/button',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsBadgeRoute = DocsComponentsBadgeRouteImport.update({
-  id: '/badge',
-  path: '/badge',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/badge',
+  path: '/components/badge',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsAvatarRoute = DocsComponentsAvatarRouteImport.update({
-  id: '/avatar',
-  path: '/avatar',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/avatar',
+  path: '/components/avatar',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsAlertDialogRoute =
   DocsComponentsAlertDialogRouteImport.update({
-    id: '/alert-dialog',
-    path: '/alert-dialog',
-    getParentRoute: () => DocsComponentsRoute,
+    id: '/components/alert-dialog',
+    path: '/components/alert-dialog',
+    getParentRoute: () => DocsRouteRoute,
   } as any)
 const DocsComponentsAlertRoute = DocsComponentsAlertRouteImport.update({
-  id: '/alert',
-  path: '/alert',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/alert',
+  path: '/components/alert',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 const DocsComponentsAccordionRoute = DocsComponentsAccordionRouteImport.update({
-  id: '/accordion',
-  path: '/accordion',
-  getParentRoute: () => DocsComponentsRoute,
+  id: '/components/accordion',
+  path: '/components/accordion',
+  getParentRoute: () => DocsRouteRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
-  '/docs/components': typeof DocsComponentsRouteWithChildren
   '/docs/installation': typeof DocsInstallationRoute
   '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/tailwind-to-kotlin': typeof DocsTailwindToKotlinRoute
@@ -283,11 +282,11 @@ export interface FileRoutesByFullPath {
   '/docs/components/spinner': typeof DocsComponentsSpinnerRoute
   '/docs/components/switch': typeof DocsComponentsSwitchRoute
   '/docs/components/tabs': typeof DocsComponentsTabsRoute
+  '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
-  '/docs/components': typeof DocsComponentsRouteWithChildren
   '/docs/installation': typeof DocsInstallationRoute
   '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/tailwind-to-kotlin': typeof DocsTailwindToKotlinRoute
@@ -323,12 +322,12 @@ export interface FileRoutesByTo {
   '/docs/components/spinner': typeof DocsComponentsSpinnerRoute
   '/docs/components/switch': typeof DocsComponentsSwitchRoute
   '/docs/components/tabs': typeof DocsComponentsTabsRoute
+  '/docs/components': typeof DocsComponentsIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/docs': typeof DocsRouteRouteWithChildren
-  '/docs/components': typeof DocsComponentsRouteWithChildren
   '/docs/installation': typeof DocsInstallationRoute
   '/docs/introduction': typeof DocsIntroductionRoute
   '/docs/tailwind-to-kotlin': typeof DocsTailwindToKotlinRoute
@@ -364,13 +363,13 @@ export interface FileRoutesById {
   '/docs/components/spinner': typeof DocsComponentsSpinnerRoute
   '/docs/components/switch': typeof DocsComponentsSwitchRoute
   '/docs/components/tabs': typeof DocsComponentsTabsRoute
+  '/docs/components/': typeof DocsComponentsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/docs'
-    | '/docs/components'
     | '/docs/installation'
     | '/docs/introduction'
     | '/docs/tailwind-to-kotlin'
@@ -406,11 +405,11 @@ export interface FileRouteTypes {
     | '/docs/components/spinner'
     | '/docs/components/switch'
     | '/docs/components/tabs'
+    | '/docs/components/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/docs'
-    | '/docs/components'
     | '/docs/installation'
     | '/docs/introduction'
     | '/docs/tailwind-to-kotlin'
@@ -446,11 +445,11 @@ export interface FileRouteTypes {
     | '/docs/components/spinner'
     | '/docs/components/switch'
     | '/docs/components/tabs'
+    | '/docs/components'
   id:
     | '__root__'
     | '/'
     | '/docs'
-    | '/docs/components'
     | '/docs/installation'
     | '/docs/introduction'
     | '/docs/tailwind-to-kotlin'
@@ -486,6 +485,7 @@ export interface FileRouteTypes {
     | '/docs/components/spinner'
     | '/docs/components/switch'
     | '/docs/components/tabs'
+    | '/docs/components/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -537,234 +537,238 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsInstallationRouteImport
       parentRoute: typeof DocsRouteRoute
     }
-    '/docs/components': {
-      id: '/docs/components'
+    '/docs/components/': {
+      id: '/docs/components/'
       path: '/components'
-      fullPath: '/docs/components'
-      preLoaderRoute: typeof DocsComponentsRouteImport
+      fullPath: '/docs/components/'
+      preLoaderRoute: typeof DocsComponentsIndexRouteImport
       parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/tabs': {
       id: '/docs/components/tabs'
-      path: '/tabs'
+      path: '/components/tabs'
       fullPath: '/docs/components/tabs'
       preLoaderRoute: typeof DocsComponentsTabsRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/switch': {
       id: '/docs/components/switch'
-      path: '/switch'
+      path: '/components/switch'
       fullPath: '/docs/components/switch'
       preLoaderRoute: typeof DocsComponentsSwitchRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/spinner': {
       id: '/docs/components/spinner'
-      path: '/spinner'
+      path: '/components/spinner'
       fullPath: '/docs/components/spinner'
       preLoaderRoute: typeof DocsComponentsSpinnerRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/sonner': {
       id: '/docs/components/sonner'
-      path: '/sonner'
+      path: '/components/sonner'
       fullPath: '/docs/components/sonner'
       preLoaderRoute: typeof DocsComponentsSonnerRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/slider': {
       id: '/docs/components/slider'
-      path: '/slider'
+      path: '/components/slider'
       fullPath: '/docs/components/slider'
       preLoaderRoute: typeof DocsComponentsSliderRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/skeleton': {
       id: '/docs/components/skeleton'
-      path: '/skeleton'
+      path: '/components/skeleton'
       fullPath: '/docs/components/skeleton'
       preLoaderRoute: typeof DocsComponentsSkeletonRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/sidebar': {
       id: '/docs/components/sidebar'
-      path: '/sidebar'
+      path: '/components/sidebar'
       fullPath: '/docs/components/sidebar'
       preLoaderRoute: typeof DocsComponentsSidebarRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/select': {
       id: '/docs/components/select'
-      path: '/select'
+      path: '/components/select'
       fullPath: '/docs/components/select'
       preLoaderRoute: typeof DocsComponentsSelectRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/radio-group': {
       id: '/docs/components/radio-group'
-      path: '/radio-group'
+      path: '/components/radio-group'
       fullPath: '/docs/components/radio-group'
       preLoaderRoute: typeof DocsComponentsRadioGroupRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/progress': {
       id: '/docs/components/progress'
-      path: '/progress'
+      path: '/components/progress'
       fullPath: '/docs/components/progress'
       preLoaderRoute: typeof DocsComponentsProgressRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/popover': {
       id: '/docs/components/popover'
-      path: '/popover'
+      path: '/components/popover'
       fullPath: '/docs/components/popover'
       preLoaderRoute: typeof DocsComponentsPopoverRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/input-otp': {
       id: '/docs/components/input-otp'
-      path: '/input-otp'
+      path: '/components/input-otp'
       fullPath: '/docs/components/input-otp'
       preLoaderRoute: typeof DocsComponentsInputOtpRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/input': {
       id: '/docs/components/input'
-      path: '/input'
+      path: '/components/input'
       fullPath: '/docs/components/input'
       preLoaderRoute: typeof DocsComponentsInputRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/dropdown-menu': {
       id: '/docs/components/dropdown-menu'
-      path: '/dropdown-menu'
+      path: '/components/dropdown-menu'
       fullPath: '/docs/components/dropdown-menu'
       preLoaderRoute: typeof DocsComponentsDropdownMenuRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/drawer': {
       id: '/docs/components/drawer'
-      path: '/drawer'
+      path: '/components/drawer'
       fullPath: '/docs/components/drawer'
       preLoaderRoute: typeof DocsComponentsDrawerRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/dialog': {
       id: '/docs/components/dialog'
-      path: '/dialog'
+      path: '/components/dialog'
       fullPath: '/docs/components/dialog'
       preLoaderRoute: typeof DocsComponentsDialogRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/date-picker': {
       id: '/docs/components/date-picker'
-      path: '/date-picker'
+      path: '/components/date-picker'
       fullPath: '/docs/components/date-picker'
       preLoaderRoute: typeof DocsComponentsDatePickerRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/data-table': {
       id: '/docs/components/data-table'
-      path: '/data-table'
+      path: '/components/data-table'
       fullPath: '/docs/components/data-table'
       preLoaderRoute: typeof DocsComponentsDataTableRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/combobox': {
       id: '/docs/components/combobox'
-      path: '/combobox'
+      path: '/components/combobox'
       fullPath: '/docs/components/combobox'
       preLoaderRoute: typeof DocsComponentsComboboxRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/collapsible': {
       id: '/docs/components/collapsible'
-      path: '/collapsible'
+      path: '/components/collapsible'
       fullPath: '/docs/components/collapsible'
       preLoaderRoute: typeof DocsComponentsCollapsibleRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/checkbox': {
       id: '/docs/components/checkbox'
-      path: '/checkbox'
+      path: '/components/checkbox'
       fullPath: '/docs/components/checkbox'
       preLoaderRoute: typeof DocsComponentsCheckboxRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/chart': {
       id: '/docs/components/chart'
-      path: '/chart'
+      path: '/components/chart'
       fullPath: '/docs/components/chart'
       preLoaderRoute: typeof DocsComponentsChartRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/carousel': {
       id: '/docs/components/carousel'
-      path: '/carousel'
+      path: '/components/carousel'
       fullPath: '/docs/components/carousel'
       preLoaderRoute: typeof DocsComponentsCarouselRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/card': {
       id: '/docs/components/card'
-      path: '/card'
+      path: '/components/card'
       fullPath: '/docs/components/card'
       preLoaderRoute: typeof DocsComponentsCardRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/calendar': {
       id: '/docs/components/calendar'
-      path: '/calendar'
+      path: '/components/calendar'
       fullPath: '/docs/components/calendar'
       preLoaderRoute: typeof DocsComponentsCalendarRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/button': {
       id: '/docs/components/button'
-      path: '/button'
+      path: '/components/button'
       fullPath: '/docs/components/button'
       preLoaderRoute: typeof DocsComponentsButtonRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/badge': {
       id: '/docs/components/badge'
-      path: '/badge'
+      path: '/components/badge'
       fullPath: '/docs/components/badge'
       preLoaderRoute: typeof DocsComponentsBadgeRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/avatar': {
       id: '/docs/components/avatar'
-      path: '/avatar'
+      path: '/components/avatar'
       fullPath: '/docs/components/avatar'
       preLoaderRoute: typeof DocsComponentsAvatarRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/alert-dialog': {
       id: '/docs/components/alert-dialog'
-      path: '/alert-dialog'
+      path: '/components/alert-dialog'
       fullPath: '/docs/components/alert-dialog'
       preLoaderRoute: typeof DocsComponentsAlertDialogRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/alert': {
       id: '/docs/components/alert'
-      path: '/alert'
+      path: '/components/alert'
       fullPath: '/docs/components/alert'
       preLoaderRoute: typeof DocsComponentsAlertRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
     '/docs/components/accordion': {
       id: '/docs/components/accordion'
-      path: '/accordion'
+      path: '/components/accordion'
       fullPath: '/docs/components/accordion'
       preLoaderRoute: typeof DocsComponentsAccordionRouteImport
-      parentRoute: typeof DocsComponentsRoute
+      parentRoute: typeof DocsRouteRoute
     }
   }
 }
 
-interface DocsComponentsRouteChildren {
+interface DocsRouteRouteChildren {
+  DocsInstallationRoute: typeof DocsInstallationRoute
+  DocsIntroductionRoute: typeof DocsIntroductionRoute
+  DocsTailwindToKotlinRoute: typeof DocsTailwindToKotlinRoute
+  DocsThemingRoute: typeof DocsThemingRoute
   DocsComponentsAccordionRoute: typeof DocsComponentsAccordionRoute
   DocsComponentsAlertRoute: typeof DocsComponentsAlertRoute
   DocsComponentsAlertDialogRoute: typeof DocsComponentsAlertDialogRoute
@@ -796,9 +800,14 @@ interface DocsComponentsRouteChildren {
   DocsComponentsSpinnerRoute: typeof DocsComponentsSpinnerRoute
   DocsComponentsSwitchRoute: typeof DocsComponentsSwitchRoute
   DocsComponentsTabsRoute: typeof DocsComponentsTabsRoute
+  DocsComponentsIndexRoute: typeof DocsComponentsIndexRoute
 }
 
-const DocsComponentsRouteChildren: DocsComponentsRouteChildren = {
+const DocsRouteRouteChildren: DocsRouteRouteChildren = {
+  DocsInstallationRoute: DocsInstallationRoute,
+  DocsIntroductionRoute: DocsIntroductionRoute,
+  DocsTailwindToKotlinRoute: DocsTailwindToKotlinRoute,
+  DocsThemingRoute: DocsThemingRoute,
   DocsComponentsAccordionRoute: DocsComponentsAccordionRoute,
   DocsComponentsAlertRoute: DocsComponentsAlertRoute,
   DocsComponentsAlertDialogRoute: DocsComponentsAlertDialogRoute,
@@ -830,26 +839,7 @@ const DocsComponentsRouteChildren: DocsComponentsRouteChildren = {
   DocsComponentsSpinnerRoute: DocsComponentsSpinnerRoute,
   DocsComponentsSwitchRoute: DocsComponentsSwitchRoute,
   DocsComponentsTabsRoute: DocsComponentsTabsRoute,
-}
-
-const DocsComponentsRouteWithChildren = DocsComponentsRoute._addFileChildren(
-  DocsComponentsRouteChildren,
-)
-
-interface DocsRouteRouteChildren {
-  DocsComponentsRoute: typeof DocsComponentsRouteWithChildren
-  DocsInstallationRoute: typeof DocsInstallationRoute
-  DocsIntroductionRoute: typeof DocsIntroductionRoute
-  DocsTailwindToKotlinRoute: typeof DocsTailwindToKotlinRoute
-  DocsThemingRoute: typeof DocsThemingRoute
-}
-
-const DocsRouteRouteChildren: DocsRouteRouteChildren = {
-  DocsComponentsRoute: DocsComponentsRouteWithChildren,
-  DocsInstallationRoute: DocsInstallationRoute,
-  DocsIntroductionRoute: DocsIntroductionRoute,
-  DocsTailwindToKotlinRoute: DocsTailwindToKotlinRoute,
-  DocsThemingRoute: DocsThemingRoute,
+  DocsComponentsIndexRoute: DocsComponentsIndexRoute,
 }
 
 const DocsRouteRouteWithChildren = DocsRouteRoute._addFileChildren(

--- a/src/routes/docs/components.index.tsx
+++ b/src/routes/docs/components.index.tsx
@@ -1,16 +1,16 @@
-import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { Separator } from "@/components/ui/separator";
 import componentMenus from "@/lib/component-menu";
 import { componentsIndexMeta } from "@/lib/seo";
 
-export const Route = createFileRoute("/docs/components")({
-  component: ComponentsLayout,
+export const Route = createFileRoute("/docs/components/")({
+  component: ComponentsView,
   head: () => ({ meta: componentsIndexMeta() }),
 });
 
-function ComponentsLayout() {
+function ComponentsView() {
   return (
-    <>
+    <div>
       <div className="mb-8">
         <h1 className="text-4xl font-bold text-foreground mb-4">Components</h1>
         <p className="text-lg text-muted-foreground">
@@ -32,8 +32,6 @@ function ComponentsLayout() {
           </Link>
         ))}
       </div>
-
-      <Outlet />
-    </>
+    </div>
   );
 }

--- a/src/routes/docs/components.tsx
+++ b/src/routes/docs/components.tsx
@@ -3,7 +3,7 @@ import { Separator } from "@/components/ui/separator";
 import componentMenus from "@/lib/component-menu";
 import { componentsIndexMeta } from "@/lib/seo";
 
-export const Route = createFileRoute("/docs/components/")({
+export const Route = createFileRoute("/docs/components")({
   component: ComponentsView,
   head: () => ({ meta: componentsIndexMeta() }),
 });

--- a/src/routes/docs/components.tsx
+++ b/src/routes/docs/components.tsx
@@ -1,16 +1,16 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, Outlet } from "@tanstack/react-router";
 import { Separator } from "@/components/ui/separator";
 import componentMenus from "@/lib/component-menu";
 import { componentsIndexMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components")({
-  component: ComponentsView,
+  component: ComponentsLayout,
   head: () => ({ meta: componentsIndexMeta() }),
 });
 
-function ComponentsView() {
+function ComponentsLayout() {
   return (
-    <div>
+    <>
       <div className="mb-8">
         <h1 className="text-4xl font-bold text-foreground mb-4">Components</h1>
         <p className="text-lg text-muted-foreground">
@@ -32,6 +32,8 @@ function ComponentsView() {
           </Link>
         ))}
       </div>
-    </div>
+
+      <Outlet />
+    </>
   );
 }


### PR DESCRIPTION
- Move components index from src/routes/docs/components/index.tsx to src/routes/docs/components.tsx
- This prevents TanStack Router from generating both /docs/components/ and /docs/components
- Sitemap now has single canonical URL per page