### PR TITLE
fix: resolve Google Search Console indexing issues

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+# Redirect trailing slash URLs to non-trailing-slash canonical form
+/docs/components/  /docs/components  301

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -11,17 +11,7 @@ export function docsMeta(
     ? `KomoUI Component: ${title}`
     : `${title} - KomoUI`;
 
-  const breadcrumbs = url
-    ? url
-        .split("/")
-        .filter(Boolean)
-        .map((segment, index, arr) => ({
-          "@type": "ListItem",
-          position: index + 1,
-          name: formatSegment(segment),
-          item: `https://komoui.site/${arr.slice(0, index + 1).join("/")}`,
-        }))
-    : [];
+  const segments = url ? url.split("/").filter(Boolean) : [];
 
   const techArticleSchema = {
     "@context": "https://schema.org",
@@ -55,30 +45,36 @@ export function docsMeta(
     "@type": "BreadcrumbList",
     itemListElement: [
       { "@type": "ListItem", position: 1, name: "Home", item: "https://komoui.site/" },
-      { "@type": "ListItem", position: 2, name: "Documentation", item: "https://komoui.site/docs" },
-      ...breadcrumbs,
+      ...segments.map((segment, index) => ({
+        "@type": "ListItem",
+        position: index + 2,
+        name: formatSegment(segment),
+        item: `https://komoui.site/${segments.slice(0, index + 1).join("/")}`,
+      })),
     ],
   };
 
-  return [
-    { title: `${title} - KomoUI` },
-    { name: "description", content: description },
-    { property: "og:title", content: pageTitle },
-    { property: "og:description", content: description },
-    { property: "og:image", content: "https://komoui.site/og-image.webp" },
-    { property: "og:image:width", content: "1200" },
-    { property: "og:image:height", content: "630" },
-    { property: "og:type", content: ogType },
-    { property: "og:url", content: canonicalUrl },
-    { property: "og:site_name", content: "KomoUI" },
-    { name: "twitter:card", content: "summary_large_image" },
-    { name: "twitter:title", content: pageTitle },
-    { name: "twitter:description", content: description },
-    { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
-    { rel: "canonical", href: canonicalUrl },
-    { "script:ld+json": techArticleSchema },
-    { "script:ld+json": breadcrumbSchema },
-  ];
+  return {
+    meta: [
+      { title: `${title} - KomoUI` },
+      { name: "description", content: description },
+      { property: "og:title", content: pageTitle },
+      { property: "og:description", content: description },
+      { property: "og:image", content: "https://komoui.site/og-image.webp" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { property: "og:type", content: ogType },
+      { property: "og:url", content: canonicalUrl },
+      { property: "og:site_name", content: "KomoUI" },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: pageTitle },
+      { name: "twitter:description", content: description },
+      { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
+      { "script:ld+json": techArticleSchema },
+      { "script:ld+json": breadcrumbSchema },
+    ],
+    links: [{ rel: "canonical", href: canonicalUrl }],
+  };
 }
 
 function formatSegment(segment: string): string {
@@ -103,36 +99,38 @@ export function homeMeta() {
     },
   };
 
-  return [
-    { title: "KomoUI - Kotlin Multiplatform UI Library for Jetpack Compose" },
-    {
-      name: "description",
-      content:
-        "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
-    },
-    { property: "og:title", content: "KomoUI" },
-    {
-      property: "og:description",
-      content:
-        "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
-    },
-    { property: "og:image", content: "https://komoui.site/og-image.webp" },
-    { property: "og:image:width", content: "1200" },
-    { property: "og:image:height", content: "630" },
-    { property: "og:type", content: "website" },
-    { property: "og:url", content: "https://komoui.site/" },
-    { property: "og:site_name", content: "KomoUI" },
-    { name: "twitter:card", content: "summary_large_image" },
-    { name: "twitter:title", content: "KomoUI" },
-    {
-      name: "twitter:description",
-      content:
-        "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
-    },
-    { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
-    { rel: "canonical", href: "https://komoui.site/" },
-    { "script:ld+json": webSiteSchema },
-  ];
+  return {
+    meta: [
+      { title: "KomoUI - Kotlin Multiplatform UI Library for Jetpack Compose" },
+      {
+        name: "description",
+        content:
+          "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+      },
+      { property: "og:title", content: "KomoUI" },
+      {
+        property: "og:description",
+        content:
+          "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+      },
+      { property: "og:image", content: "https://komoui.site/og-image.webp" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://komoui.site/" },
+      { property: "og:site_name", content: "KomoUI" },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: "KomoUI" },
+      {
+        name: "twitter:description",
+        content:
+          "KomoUI is a Kotlin Multiplatform UI library for Jetpack Compose, providing beautifully designed components that you can copy and paste into your apps.",
+      },
+      { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
+      { "script:ld+json": webSiteSchema },
+    ],
+    links: [{ rel: "canonical", href: "https://komoui.site/" }],
+  };
 }
 
 export function componentsIndexMeta() {
@@ -194,35 +192,37 @@ export function componentsIndexMeta() {
     ],
   };
 
-  return [
-    { title: "Components - KomoUI" },
-    {
-      name: "description",
-      content:
-        "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
-    },
-    { property: "og:title", content: "Components - KomoUI" },
-    {
-      property: "og:description",
-      content:
-        "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
-    },
-    { property: "og:image", content: "https://komoui.site/og-image.webp" },
-    { property: "og:image:width", content: "1200" },
-    { property: "og:image:height", content: "630" },
-    { property: "og:type", content: "website" },
-    { property: "og:url", content: "https://komoui.site/docs/components" },
-    { property: "og:site_name", content: "KomoUI" },
-    { name: "twitter:card", content: "summary_large_image" },
-    { name: "twitter:title", content: "Components - KomoUI" },
-    {
-      name: "twitter:description",
-      content:
-        "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
-    },
-    { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
-    { rel: "canonical", href: "https://komoui.site/docs/components" },
-    { "script:ld+json": collectionPageSchema },
-    { "script:ld+json": breadcrumbSchema },
-  ];
+  return {
+    meta: [
+      { title: "Components - KomoUI" },
+      {
+        name: "description",
+        content:
+          "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+      },
+      { property: "og:title", content: "Components - KomoUI" },
+      {
+        property: "og:description",
+        content:
+          "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+      },
+      { property: "og:image", content: "https://komoui.site/og-image.webp" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://komoui.site/docs/components" },
+      { property: "og:site_name", content: "KomoUI" },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:title", content: "Components - KomoUI" },
+      {
+        name: "twitter:description",
+        content:
+          "Browse all KomoUI components for Jetpack Compose. Buttons, inputs, dialogs, navigation, and more.",
+      },
+      { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
+      { "script:ld+json": collectionPageSchema },
+      { "script:ld+json": breadcrumbSchema },
+    ],
+    links: [{ rel: "canonical", href: "https://komoui.site/docs/components" }],
+  };
 }

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -76,18 +76,8 @@ export function docsMeta(
     { name: "twitter:description", content: description },
     { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
     { rel: "canonical", href: canonicalUrl },
-    {
-      script: {
-        type: "application/ld+json",
-        children: JSON.stringify(techArticleSchema),
-      },
-    },
-    {
-      script: {
-        type: "application/ld+json",
-        children: JSON.stringify(breadcrumbSchema),
-      },
-    },
+    { "script:ld+json": techArticleSchema },
+    { "script:ld+json": breadcrumbSchema },
   ];
 }
 
@@ -141,12 +131,7 @@ export function homeMeta() {
     },
     { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
     { rel: "canonical", href: "https://komoui.site/" },
-    {
-      script: {
-        type: "application/ld+json",
-        children: JSON.stringify(webSiteSchema),
-      },
-    },
+    { "script:ld+json": webSiteSchema },
   ];
 }
 
@@ -237,17 +222,7 @@ export function componentsIndexMeta() {
     },
     { name: "twitter:image", content: "https://komoui.site/og-image.webp" },
     { rel: "canonical", href: "https://komoui.site/docs/components" },
-    {
-      script: {
-        type: "application/ld+json",
-        children: JSON.stringify(collectionPageSchema),
-      },
-    },
-    {
-      script: {
-        type: "application/ld+json",
-        children: JSON.stringify(breadcrumbSchema),
-      },
-    },
+    { "script:ld+json": collectionPageSchema },
+    { "script:ld+json": breadcrumbSchema },
   ];
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -5,6 +5,7 @@ export function getRouter() {
   const router = createRouter({
     routeTree,
     scrollRestoration: true,
+    trailingSlash: "never",
   });
 
   return router;

--- a/src/routes/docs/components.index.tsx
+++ b/src/routes/docs/components.index.tsx
@@ -5,7 +5,7 @@ import { componentsIndexMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/")({
   component: ComponentsView,
-  head: () => ({ meta: componentsIndexMeta() }),
+  head: () => componentsIndexMeta(),
 });
 
 function ComponentsView() {

--- a/src/routes/docs/components/accordion.tsx
+++ b/src/routes/docs/components/accordion.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/accordion")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/accordion", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/accordion", "Components"),
 });

--- a/src/routes/docs/components/alert-dialog.tsx
+++ b/src/routes/docs/components/alert-dialog.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/alert-dialog")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/alert-dialog", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/alert-dialog", "Components"),
 });

--- a/src/routes/docs/components/alert.tsx
+++ b/src/routes/docs/components/alert.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/alert")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/alert", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/alert", "Components"),
 });

--- a/src/routes/docs/components/avatar.tsx
+++ b/src/routes/docs/components/avatar.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/avatar")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/avatar", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/avatar", "Components"),
 });

--- a/src/routes/docs/components/badge.tsx
+++ b/src/routes/docs/components/badge.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/badge")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/badge", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/badge", "Components"),
 });

--- a/src/routes/docs/components/button.tsx
+++ b/src/routes/docs/components/button.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/button")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/button", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/button", "Components"),
 });

--- a/src/routes/docs/components/calendar.tsx
+++ b/src/routes/docs/components/calendar.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/calendar")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/calendar", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/calendar", "Components"),
 });

--- a/src/routes/docs/components/card.tsx
+++ b/src/routes/docs/components/card.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/card")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/card", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/card", "Components"),
 });

--- a/src/routes/docs/components/carousel.tsx
+++ b/src/routes/docs/components/carousel.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/carousel")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/carousel", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/carousel", "Components"),
 });

--- a/src/routes/docs/components/chart.tsx
+++ b/src/routes/docs/components/chart.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/chart")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/chart", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/chart", "Components"),
 });

--- a/src/routes/docs/components/checkbox.tsx
+++ b/src/routes/docs/components/checkbox.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/checkbox")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/checkbox", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/checkbox", "Components"),
 });

--- a/src/routes/docs/components/collapsible.tsx
+++ b/src/routes/docs/components/collapsible.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/collapsible")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/collapsible", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/collapsible", "Components"),
 });

--- a/src/routes/docs/components/combobox.tsx
+++ b/src/routes/docs/components/combobox.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/combobox")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/combobox", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/combobox", "Components"),
 });

--- a/src/routes/docs/components/data-table.tsx
+++ b/src/routes/docs/components/data-table.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/data-table")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/data-table", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/data-table", "Components"),
 });

--- a/src/routes/docs/components/date-picker.tsx
+++ b/src/routes/docs/components/date-picker.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/date-picker")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/date-picker", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/date-picker", "Components"),
 });

--- a/src/routes/docs/components/dialog.tsx
+++ b/src/routes/docs/components/dialog.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/dialog")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/dialog", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/dialog", "Components"),
 });

--- a/src/routes/docs/components/drawer.tsx
+++ b/src/routes/docs/components/drawer.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/drawer")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/drawer", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/drawer", "Components"),
 });

--- a/src/routes/docs/components/dropdown-menu.tsx
+++ b/src/routes/docs/components/dropdown-menu.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/dropdown-menu")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/dropdown-menu", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/dropdown-menu", "Components"),
 });

--- a/src/routes/docs/components/input-otp.tsx
+++ b/src/routes/docs/components/input-otp.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/input-otp")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/input-otp", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/input-otp", "Components"),
 });

--- a/src/routes/docs/components/input.tsx
+++ b/src/routes/docs/components/input.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/input")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/input", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/input", "Components"),
 });

--- a/src/routes/docs/components/popover.tsx
+++ b/src/routes/docs/components/popover.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/popover")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/popover", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/popover", "Components"),
 });

--- a/src/routes/docs/components/progress.tsx
+++ b/src/routes/docs/components/progress.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/progress")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/progress", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/progress", "Components"),
 });

--- a/src/routes/docs/components/radio-group.tsx
+++ b/src/routes/docs/components/radio-group.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/radio-group")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/radio-group", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/radio-group", "Components"),
 });

--- a/src/routes/docs/components/select.tsx
+++ b/src/routes/docs/components/select.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/select")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/select", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/select", "Components"),
 });

--- a/src/routes/docs/components/sidebar.tsx
+++ b/src/routes/docs/components/sidebar.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/sidebar")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/sidebar", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/sidebar", "Components"),
 });

--- a/src/routes/docs/components/skeleton.tsx
+++ b/src/routes/docs/components/skeleton.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/skeleton")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/skeleton", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/skeleton", "Components"),
 });

--- a/src/routes/docs/components/slider.tsx
+++ b/src/routes/docs/components/slider.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/slider")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/slider", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/slider", "Components"),
 });

--- a/src/routes/docs/components/sonner.tsx
+++ b/src/routes/docs/components/sonner.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/sonner")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/sonner", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/sonner", "Components"),
 });

--- a/src/routes/docs/components/spinner.tsx
+++ b/src/routes/docs/components/spinner.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/spinner")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/spinner", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/spinner", "Components"),
 });

--- a/src/routes/docs/components/switch.tsx
+++ b/src/routes/docs/components/switch.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/switch")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/switch", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/switch", "Components"),
 });

--- a/src/routes/docs/components/tabs.tsx
+++ b/src/routes/docs/components/tabs.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/components/tabs")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/components/tabs", "Components") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/components/tabs", "Components"),
 });

--- a/src/routes/docs/installation.tsx
+++ b/src/routes/docs/installation.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/installation")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/installation", "Getting Started") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/installation", "Getting Started"),
 });

--- a/src/routes/docs/introduction.tsx
+++ b/src/routes/docs/introduction.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/introduction")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/introduction", "Getting Started") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/introduction", "Getting Started"),
 });

--- a/src/routes/docs/tailwind-to-kotlin.tsx
+++ b/src/routes/docs/tailwind-to-kotlin.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/tailwind-to-kotlin")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/tailwind-to-kotlin", "Getting Started") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/tailwind-to-kotlin", "Getting Started"),
 });

--- a/src/routes/docs/theming.tsx
+++ b/src/routes/docs/theming.tsx
@@ -4,5 +4,5 @@ import { docsMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/docs/theming")({
   component: () => <Content />,
-  head: () => ({ meta: docsMeta(frontmatter.title, frontmatter.description, "/docs/theming", "Getting Started") }),
+  head: () => docsMeta(frontmatter.title, frontmatter.description, "/docs/theming", "Getting Started"),
 });

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { Examples } from "@/components/home/examples";
 import { homeMeta } from "@/lib/seo";
 
 export const Route = createFileRoute("/")({
-  head: () => ({ meta: homeMeta() }),
+  head: () => homeMeta(),
   component: HomePage,
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,19 @@ export default defineConfig({
       prerender: {
         enabled: true,
         crawlLinks: true,
+        // Emit flat `<path>.html` files instead of `<path>/index.html`. On
+        // Cloudflare's asset server this makes the non-trailing URL (the form
+        // used in our sitemap and rel=canonical tags) the 200 canonical, instead
+        // of 307-redirecting it to a trailing-slash variant.
+        autoSubfolderIndex: false,
+        // The /docs/components index route is crawlable as both /docs/components
+        // and /docs/components/. Keep the trailing-slash variant out of the
+        // sitemap so only the canonical (non-trailing) URL is submitted to Google.
+        onSuccess: ({ page }) => {
+          if (page.path !== "/" && page.path.endsWith("/")) {
+            return { ...page, sitemap: { ...page.sitemap, exclude: true } };
+          }
+        },
       },
       sitemap: {
         enabled: true,


### PR DESCRIPTION
Problem:
- JSON-LD structured data was rendered as <meta script="[object Object]"/> instead of <script type="application/ld+json">, making all schema.org markup invisible to search engines
- TanStack Router was using 307 (temporary) redirects for trailing-slash URL normalization, causing 'Redirect error' and 'Page with redirect' in Google Search Console
- Both /docs/components/ and /docs/components were being indexed as duplicate content with no consistent canonical

Solution:
- src/lib/seo.ts: replace { script: { type: 'application/ld+json', ... } } with { 'script:ld+json': schemaObject } — TanStack Router has built-in handling for this key and emits proper <script type="application/ld+json"> tags (verified in built output)
- src/router.tsx: add trailingSlash: 'never' — changes TanStack Router's redirect from 307 Temporary to 301 Permanent, consolidating duplicate URLs and fixing the redirect error
- public/_redirects: Cloudflare edge-level 301 redirect from /docs/components/ → /docs/components as a safety net for previously indexed trailing-slash URLs